### PR TITLE
Add .use method for chaining plugins.

### DIFF
--- a/exercise.js
+++ b/exercise.js
@@ -17,9 +17,15 @@ function Exercise () {
   this._cleanups   = []
 }
 
-
 inherits(Exercise, EventEmitter)
 
+// exercise plugin convenience
+// plugin arg is just a function that takes an exercise
+// variable args to `use` are forwarded to plugin
+Exercise.prototype.use = function use(plugin) {
+  var args = [].slice.call(arguments, 1)
+  return plugin.apply(this, [this].concat(args))
+}
 
 // for addVerifyProcessor and addVerifySetup
 function verifyOnly (fn) {

--- a/exercise.js
+++ b/exercise.js
@@ -24,7 +24,7 @@ inherits(Exercise, EventEmitter)
 // variable args to `use` are forwarded to plugin
 Exercise.prototype.use = function use(plugin) {
   var args = [].slice.call(arguments, 1)
-  return plugin.apply(this, [this].concat(args))
+  return plugin.apply(this, [ this ].concat(args))
 }
 
 // for addVerifyProcessor and addVerifySetup


### PR DESCRIPTION
Trivial change but makes it feel more like you're performing a sanctioned activity rather than hacking an exercise object.

Converts this:

```js
exercise = execute(exercise)
exercise = comparestdout(exercise)
exercise = boilerplate(exercise)
exercise = wrappedexec(exercise)
```

To this:

```js
exercise = exercise.use(execute)
                   .use(comparestdout)
                   .use(boilerplate)
                   .use(wrappedexec)
```