### PR TITLE
make execute spawn options configurable

### DIFF
--- a/execute.js
+++ b/execute.js
@@ -5,7 +5,9 @@ const spawn = require('child_process').spawn
     , xtend = require('xtend')
 
 
-function execute (exercise) {
+function execute (exercise, opts) {
+  if (!opts) opts = {}
+  
   exercise.addSetup(setup)
   exercise.addProcessor(processor)
 
@@ -31,65 +33,70 @@ function execute (exercise) {
     })
   }
 
-
   return exercise
-}
+  
+  function setup (mode, callback) {
+    this.submission = this.args[0] // first arg obviously
 
+    // default args, override if you want to pass special args to the
+    // solution and/or submission, override this.setup to do this
+    this.submissionArgs = Array.prototype.slice.call(1, this.args)
+    this.solutionArgs   = Array.prototype.slice.call(1, this.args)
 
-function setup (mode, callback) {
-  this.submission = this.args[0] // first arg obviously
+    // edit/override if you want to alter the child process environment
+    this.env            = xtend(process.env)
 
-  // default args, override if you want to pass special args to the
-  // solution and/or submission, override this.setup to do this
-  this.submissionArgs = Array.prototype.slice.call(1, this.args)
-  this.solutionArgs   = Array.prototype.slice.call(1, this.args)
+    // set this.solution if your solution is elsewhere
+    if (!this.solution)
+      this.solution = path.join(this.dir, './solution/solution.js')
+      
+    this.solutionCommand   = [ this.solution ].concat(this.solutionArgs)
+    this.submissionCommand = [ this.submission ].concat(this.submissionArgs)
 
-  // edit/override if you want to alter the child process environment
-  this.env            = xtend(process.env)
-
-  // set this.solution if your solution is elsewhere
-  if (!this.solution)
-    this.solution = path.join(this.dir, './solution/solution.js')
-
-  process.nextTick(callback)
-}
-
-
-function kill () {
-  ;[ this.submissionChild, this.solutionChild ].forEach(function (child) {
-    if (child && typeof child.kill == 'function')
-      child.kill()
-  })
-
-  setTimeout(function () {
-    this.emit('executeEnd')
-  }.bind(this), 10)
-}
-
-
-function processor (mode, callback) {
-  var ended = after(mode == 'verify' ? 2 : 1, kill.bind(this))
-
-  this.submissionChild  = spawn(process.execPath, [ this.submission ].concat(this.submissionArgs), this.env)
-  this.submissionStdout = this.getStdout('submission', this.submissionChild)
-
-  setImmediate(function () { // give other processors a chance to overwrite stdout
-    this.submissionStdout.on('end', ended)
-  }.bind(this))
-
-  if (mode == 'verify') {
-    this.solutionChild  = spawn(process.execPath, [ this.solution ].concat(this.solutionArgs), this.env)
-    this.solutionStdout = this.getStdout('solution', this.solutionChild)
-
-    setImmediate(function () { // give other processors a chance to overwrite stdout
-      this.solutionStdout.on('end', ended)
-    }.bind(this))
+    process.nextTick(callback)
   }
 
-  process.nextTick(function () {
-    callback(null, true)
-  })
-}
 
+  function kill () {
+    ;[ this.submissionChild, this.solutionChild ].forEach(function (child) {
+      if (child && typeof child.kill == 'function')
+        child.kill()
+    })
+
+    setTimeout(function () {
+      this.emit('executeEnd')
+    }.bind(this), 10)
+  }
+
+
+  function processor (mode, callback) {
+    var ended = after(mode == 'verify' ? 2 : 1, kill.bind(this))
+    
+    // backwards compat for workshops that use older custom setup functions
+    if (!this.solutionCommand) this.solutionCommand = [ this.solution ].concat(this.solutionArgs)
+    if (!this.submissionCommand) this.submissionCommand = [ this.submission ].concat(this.submissionArgs)
+    
+    this.submissionChild  = spawn(opts.exec || process.execPath, this.submissionCommand, this.env)
+    this.submissionStdout = this.getStdout('submission', this.submissionChild)
+
+    setImmediate(function () { // give other processors a chance to overwrite stdout
+      this.submissionStdout.on('end', ended)
+    }.bind(this))
+
+    if (mode == 'verify') {
+      this.solutionChild  = spawn(opts.exec || process.execPath, this.solutionCommand, this.env)
+      this.solutionStdout = this.getStdout('solution', this.solutionChild)
+
+      setImmediate(function () { // give other processors a chance to overwrite stdout
+        this.solutionStdout.on('end', ended)
+      }.bind(this))
+    }
+
+    process.nextTick(function () {
+      callback(null, true)
+    })
+  }
+  
+}
 
 module.exports = execute


### PR DESCRIPTION
i'm working on a workshopper where given `data-plumber verify foo.json` workshopper needs to run `gasket --config foo.json`

currently `workshopper-exercise/execute` is hardcoded to run `node [this.solution] [this.solutionArgs ...]` but this PR makes the command configurable via either a new `exec` option to change `node` to whatever you want:

```
execute(exercise, {exec: path.resolve(__dirname, '..', '..', 'node_modules', 'gasket', 'bin.js')})
```

or via overriding `exercise.setup` and having it return a custom `.solutionCommand` or `.submissionCommand`
