### PR TITLE
Fallback to default solution.js if locale subdir hasn't got one

### DIFF
--- a/execute.js
+++ b/execute.js
@@ -17,25 +17,35 @@ function execute (exercise, opts) {
     return child.stdout
   }
 
-  exercise.getSolutionFiles = function (callback, useDefault) {
-    var translated = path.join(this.dir, useDefault ? './solution' : ('./solution_' + this.lang))
-    fs.exists(translated, function (exists) {
-      var solutionDir = exists ? translated : path.join(this.dir, './solution')
+  exercise.getSolutionFiles = function (callback) {
+    var translated = path.join(this.dir, './solution_' + this.lang)
+    var fallback = path.join(this.dir, './solution')
 
-      fs.readdir(solutionDir, function (err, list) {
-        if (err)
-          return callback(err)
+    checkPath(translated, function(err, list) {
+      if (list && list.length > 0)
+        return callback(null, list)
 
-        list = list
-          .filter(function (f) { return (/\.js$/).test(f) })
-          .map(function (f) { return path.join(solutionDir, f)})
+      checkPath(fallback, callback)
+    });
 
-        if (0 === list.length && exists && !useDefault)
-          return exercise.getSolutionFiles(callback, true)
 
-        callback(null, list)
+    function checkPath(dir, callback) {
+      fs.exists(dir, function (exists) {
+        if (!exists)
+          return callback(null, []);
+
+        fs.readdir(dir, function (err, list) {
+          if (err)
+            return callback(err)
+
+          list = list
+            .filter(function (f) { return (/\.js$/).test(f) })
+            .map(function (f) { return path.join(dir, f)})
+
+          callback(null, list)
+        })
       })
-    }.bind(this))
+    }
   }
 
   return exercise

--- a/execute.js
+++ b/execute.js
@@ -17,8 +17,8 @@ function execute (exercise, opts) {
     return child.stdout
   }
 
-  exercise.getSolutionFiles = function (callback) {
-    var translated = path.join(this.dir, './solution_' + this.lang)
+  exercise.getSolutionFiles = function (callback, useDefault) {
+    var translated = path.join(this.dir, useDefault ? './solution' : ('./solution_' + this.lang))
     fs.exists(translated, function (exists) {
       var solutionDir = exists ? translated : path.join(this.dir, './solution')
 
@@ -29,6 +29,9 @@ function execute (exercise, opts) {
         list = list
           .filter(function (f) { return (/\.js$/).test(f) })
           .map(function (f) { return path.join(solutionDir, f)})
+
+        if (0 === list.length && exists && !useDefault)
+          return exercise.getSolutionFiles(callback, true)
 
         callback(null, list)
       })


### PR DESCRIPTION
Hey guys,

I just realized I sometimes have a use case where an exercise needs per-locale files / display / output confirmation, but the `solution.js` code itself is unchanged. For instance, see https://github.com/koajs/kick-off-koa/tree/master/exercises/response_body

In order not to duplicate the `solution.js` file across locales, we should fallback to `solution/`'s file when the locale-specific `solution_xx` subdir doesn't provide one. Here's a simple patch for that.

It would be **awesome** if 1+ contribs (e.g. @martinheidegger or @rvagg or @julianduque) could :+1: this, merge, and version bump on npm so I can change the minimum dep on the relevant workshops :wink: 

Cheers!