### PR TITLE
ko.json added

### DIFF
--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -1,0 +1,14 @@
+{
+    "compare": {
+        "title": "제출된 결과와 목표 결과의 비교입니다:"
+      , "actual": "제출된 결과"
+      , "expected": "목표 결과"
+      , "pass": "제출된 결과가 목표 결과와 일치합니다"
+      , "fail": "제출된 결과가 목표 결과와 일치하지 않습니다!"
+    }
+  , "error": {
+        "missing_problem": "[{{{name}}}]에 대한 problem.txt 파일이나 problem.md 파일을 찾을 수 없습니다  {{{err}}}"
+      , "submission_no_file": "파일이 존재하지 않습니다: {{{submission}}}"
+      , "submission_not_regular": "이 파일은 정규 파일이 아닙니다: {{{submission}}}"
+    }
+}


### PR DESCRIPTION
I've found an error when playing with `yosuke-furukawa/tower-of-babel` in Korean.
It seems to be needed Korean translation when submit my answer

So, I added it
And it works well

the below is the error message
```
?exercises.CLASS.compare.title || common.exercise.compare.title?

/usr/local/lib/node_modules/tower-of-babel/node_modules/workshopper-exercise/comparestdout.js:19
  return new Array(sz + 1).join(ch)
         ^
RangeError: Invalid array length
    at repeat (/usr/local/lib/node_modules/tower-of-babel/node_modules/workshopper-exercise/comparestdout.js:19:10)
    at center (/usr/local/lib/node_modules/tower-of-babel/node_modules/workshopper-exercise/comparestdout.js:25:13)
    at Exercise.transform (/usr/local/lib/node_modules/tower-of-babel/node_modules/workshopper-exercise/comparestdout.js:57:40)
    at Transform._read (/usr/local/lib/node_modules/tower-of-babel/node_modules/workshopper-exercise/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at Transform._write (/usr/local/lib/node_modules/tower-of-babel/node_modules/workshopper-exercise/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/usr/local/lib/node_modules/tower-of-babel/node_modules/workshopper-exercise/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/usr/local/lib/node_modules/tower-of-babel/node_modules/workshopper-exercise/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at Transform.Writable.write (/usr/local/lib/node_modules/tower-of-babel/node_modules/workshopper-exercise/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at Stream.ondata (stream.js:51:26)
    at Stream.emit (events.js:107:17)
```