### PR TITLE
Added missing strings file for Italian language

### DIFF
--- a/i18n/it.json
+++ b/i18n/it.json
@@ -1,0 +1,14 @@
+{
+    "compare": {
+        "title": "I risultati della tua soluzione a confronto con quelli previsti:"
+      , "actual": "ATTUALI"
+      , "expected": "PREVISTI"
+      , "pass": "I risultati coincidono con quelli previsti"
+      , "fail": "I risultati non coincidono con quelli previsti!"
+    }
+  , "error": {
+        "missing_problem": "Impossibile trovare problem.txt o problem.md per [{{{name}}}] {{{err}}}"
+      , "submission_no_file": "File mancante: {{{submission}}}"
+      , "submission_not_regular": "File non corretto: {{{submission}}}"
+    }
+}


### PR DESCRIPTION
Added missing file i18n/it.json which caused some strings to be missing when the language selected was Italian.

In particular it would not carry out correctly on the learnyounode module while verifying an exercise if the language selected was Italian.

Fixes: https://github.com/nodeschool/discussions/issues/1700